### PR TITLE
Proc 3 criacao de uma nova tarefa job

### DIFF
--- a/app/controllers/api/v1/admins_controller.rb
+++ b/app/controllers/api/v1/admins_controller.rb
@@ -6,13 +6,14 @@ module Api
       before_action :retrieve_admin, only: %i[update show]
 
       def index
-        admins = Admin.all
+        admins = Admin.includes(:profile_admin).all
 
         render json: AdminSerializer.new(
           admins,
           meta: {
             total_count: admins.offset(nil).limit(nil).count
-          }
+          },
+          include: %i[profile_admin]
         ), status: :ok
       end
 

--- a/spec/controllers/api/v1/admins_controller_spec.rb
+++ b/spec/controllers/api/v1/admins_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Api::V1::AdminsController, type: :request do
               'profile_admin' => { 'data' => nil }
             }
           }],
+          'included' => [],
           'meta' => {
             'total_count' => 1
           }

--- a/spec/controllers/api/v1/powers_controller_spec.rb
+++ b/spec/controllers/api/v1/powers_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Api::V1::PowersController, type: :request do
         post '/api/v1/powers', params: {
           power: {
             description: 'texto',
-            category: 5
+            category: :lawgeneral
           }
         }, headers: { Authorization: "Bearer #{admin.jwt_token}", Accept: 'application/json' }
 

--- a/spec/models/power_spec.rb
+++ b/spec/models/power_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Power, type: :model do
       end
 
       it 'altera categoria' do
-        power.update(category: 2)
-        expect(power.category).to eq(2)
+        power.update(category: 'admspecificprev')
+        expect(power.category).to eq('admspecificprev')
       end
     end
   end


### PR DESCRIPTION
 Description

This PR aims to introduce an endpoint to expose OfficeType data, within it, customers are able to perform all CRUD operations against the `api/v1/office_types` endpoint. **You need to be logged in as an admin**.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- I have applied respective changes on the controller action;

----

#### New return example:
```JSON
{
  "data": [
    {
      "id": "2",
      "type": "admin",
      "attributes": {
        "email": "adminapi@..."
      },
      "relationships": {
        "profile_admin": {
          "data": {
            "id": "2",
            "type": "profile_admin"
          }
        }
      }
    },
    {
      "id": "1",
      "type": "admin",
      "attributes": {
        "email": "adminfront@..."
      },
      "relationships": {
        "profile_admin": {
          "data": {
            "id": "1",
            "type": "profile_admin"
          }
        }
      }
    }
  ],
  "included": [
    {
      "id": "2",
      "type": "profile_admin",
      "attributes": {
        "role": "lawyer",
        "name": "Brian",
        "last_name": "McGuire (AdminAPI)",
        "email": "adminapi@..."
      }
    },
    {
      "id": "1",
      "type": "profile_admin",
      "attributes": {
        "role": "lawyer",
        "name": "Ryan",
        "last_name": "McGuire (FrontAdmin)",
        "email": "adminfront@..."
      }
    }
  ],
  "meta": {
    "total_count": 2
  }
}
```

