### PR TITLE
Proc 27 alterar a estrutura de representantes

### DIFF
--- a/app/controllers/api/v1/profile_customers_controller.rb
+++ b/app/controllers/api/v1/profile_customers_controller.rb
@@ -77,6 +77,7 @@ module Api
           customer_attributes: %i[id email password password_confirmation],
           phones_attributes: %i[id phone_number],
           emails_attributes: %i[id email],
+          represent_attributes: %i[id profile_admin_id],
           customer_files_attributes: %i[id file_description]
         )
       end

--- a/app/models/profile_admin.rb
+++ b/app/models/profile_admin.rb
@@ -10,7 +10,8 @@ class ProfileAdmin < ApplicationRecord
     trainee: 'trainee',
     secretary: 'secretary',
     counter: 'counter',
-    excounter: 'excounter'
+    excounter: 'excounter',
+    representant: 'representant'
   }
 
   enum status: {

--- a/app/models/profile_customer.rb
+++ b/app/models/profile_customer.rb
@@ -56,7 +56,10 @@ class ProfileCustomer < ApplicationRecord
 
   has_one :represent
 
-  accepts_nested_attributes_for :customer_files, :customer, :addresses, :phones, :emails, :bank_accounts, reject_if: :all_blank
+  accepts_nested_attributes_for :customer_files, :customer, :addresses,
+                                :phones, :emails, :bank_accounts, :represent,
+                                reject_if: :all_blank
+
   validates :name, presence: true
   validates :gender, presence: true
 

--- a/app/models/represent.rb
+++ b/app/models/represent.rb
@@ -2,4 +2,5 @@
 
 class Represent < ApplicationRecord
   belongs_to :profile_customer
+  belongs_to :profile_admin
 end

--- a/app/serializers/profile_customer_serializer.rb
+++ b/app/serializers/profile_customer_serializer.rb
@@ -8,7 +8,7 @@ class ProfileCustomerSerializer
   attributes :addresses, :bank_accounts, :birth, :capacity, :civil_status,
              :company, :customer_id, :emails, :gender, :inss_password,
              :mother_name, :nationality, :nit, :number_benefit, :phones,
-             :profession, :rg, :status, if: proc { |_, options| options[:action] == 'show' }
+             :profession, :rg, :status, :represent, if: proc { |_, options| options[:action] == 'show' }
 
   attribute :default_phone do |object|
     object.phones.first&.phone_number

--- a/db/migrate/20231211105803_add_profile_customer_to_represents.rb
+++ b/db/migrate/20231211105803_add_profile_customer_to_represents.rb
@@ -1,0 +1,6 @@
+class AddProfileCustomerToRepresents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :represents, :profile_admin, null: false, foreign_key: true, index: true
+    remove_column :represents, :represented_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -395,10 +395,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_234247) do
   end
 
   create_table "represents", force: :cascade do |t|
-    t.integer "represented_id"
     t.bigint "profile_customer_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "represented_id"
     t.index ["profile_customer_id"], name: "index_represents_on_profile_customer_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_12_234247) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_105803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -398,7 +398,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_234247) do
     t.bigint "profile_customer_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "represented_id"
+    t.bigint "profile_admin_id", null: false
+    t.index ["profile_admin_id"], name: "index_represents_on_profile_admin_id"
     t.index ["profile_customer_id"], name: "index_represents_on_profile_customer_id"
   end
 
@@ -475,5 +476,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_234247) do
   add_foreign_key "profile_customers", "customers"
   add_foreign_key "recommendations", "profile_customers"
   add_foreign_key "recommendations", "works"
+  add_foreign_key "represents", "profile_admins"
   add_foreign_key "represents", "profile_customers"
 end

--- a/spec/controllers/api/v1/profile_customers_controller_spec.rb
+++ b/spec/controllers/api/v1/profile_customers_controller_spec.rb
@@ -236,7 +236,8 @@ RSpec.describe Api::V1::ProfileCustomersController, type: :request do
               'bank_accounts' => [],
               'default_phone' => nil,
               'default_email' => nil,
-              'city' => nil
+              'city' => nil,
+              'represent' => nil
             }
           }
         )

--- a/spec/models/profile_customer_spec.rb
+++ b/spec/models/profile_customer_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProfileCustomer, type: :model do
+  context 'Attributes' do
+    it {
+      is_expected.to have_attributes(
+        id: nil,
+        customer_type: nil,
+        name: nil,
+        last_name: nil,
+        gender: nil,
+        rg: nil,
+        cpf: nil,
+        cnpj: nil,
+        nationality: nil,
+        civil_status: nil,
+        capacity: nil,
+        profession: nil,
+        company: nil,
+        birth: nil,
+        mother_name: nil,
+        number_benefit: nil,
+        status: nil,
+        document: nil,
+        nit: nil,
+        inss_password: nil,
+        invalid_person: nil,
+        customer_id: nil,
+        created_at: nil,
+        updated_at: nil
+      )
+    }
+  end
+
+  context 'Relations' do
+    it { is_expected.to have_many(:customer_addresses).dependent(:destroy) }
+    it { is_expected.to have_many(:addresses).through(:customer_addresses) }
+
+    it { is_expected.to have_many(:customer_phones).dependent(:destroy) }
+    it { is_expected.to have_many(:phones).through(:customer_phones) }
+
+    it { is_expected.to have_many(:customer_emails).dependent(:destroy) }
+    it { is_expected.to have_many(:emails).through(:customer_emails) }
+
+    it { is_expected.to have_many(:customer_bank_accounts).dependent(:destroy) }
+    it { is_expected.to have_many(:bank_accounts).through(:customer_bank_accounts) }
+
+    it { is_expected.to have_many(:customer_works).dependent(:destroy) }
+    it { is_expected.to have_many(:works).through(:customer_works) }
+
+    it { is_expected.to have_many(:customer_files).dependent(:destroy) }
+
+    it { is_expected.to have_one(:represent) }
+  end
+
+  context 'Nested Attributes' do
+    it { is_expected.to accept_nested_attributes_for(:customer_files) }
+    it { is_expected.to accept_nested_attributes_for(:customer) }
+    it { is_expected.to accept_nested_attributes_for(:addresses) }
+    it { is_expected.to accept_nested_attributes_for(:phones) }
+    it { is_expected.to accept_nested_attributes_for(:emails) }
+    it { is_expected.to accept_nested_attributes_for(:bank_accounts) }
+    it { is_expected.to accept_nested_attributes_for(:represent) }
+  end
+
+  context 'Validations' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:gender) }
+  end
+
+  context 'Instance Methods' do
+    it '#full_name, returns a string with first and last_name' do
+      profile = build(:profile_customer)
+      expect(profile.full_name).to eq("#{profile.name} #{profile.last_name}")
+    end
+
+    context '#last_email' do
+      let(:profile) { create(:profile_customer) }
+
+      it 'returns the I18n general.without email when there is no email' do
+        expect(profile.last_email).to eq(I18n.t('general.without_email'))
+      end
+
+      it 'returns the last email when applicable' do
+        email = Faker::Internet.email
+        profile.emails << build(:email, email: email)
+        expect(profile.last_email).to eq(email)
+      end
+    end
+  end
+end

--- a/spec/models/represent_spec.rb
+++ b/spec/models/represent_spec.rb
@@ -3,5 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Represent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'Attributes' do
+    it {
+      is_expected.to have_attributes(
+        id: nil,
+        profile_customer_id: nil,
+        created_at: nil,
+        updated_at: nil,
+        profile_admin_id: nil
+      )
+    }
+  end
+
+  context 'Relations' do
+    it { is_expected.to belong_to(:profile_customer) }
+    it { is_expected.to belong_to(:profile_admin) }
+  end
 end


### PR DESCRIPTION
# Descrição

Essa PR tem como objetivo modificar a atual estrutura de `Representante`, essa alteração se faz necessária para que a ferramenta tenha a capacidade de adicionar representantes _(admins com determinada role)_ a determinados clientes. Para atingir o objetivo foram realizadas as seguintes modificações:
- adicionado suporte aos attrs de representante na controller de `profile_customers`;
- adicionado nova role em admins _(`representant`)_;
- alterado modelo de `Represent` para que seja adicionado uma referência de `profile_admins` _(isso nos permite alterar o nome do atributo, tipo e adicionar index em represents através do ID do admin)_; 
- testes;

## Tipo de alteração

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---
### O que irá mudar?

Quando aprovado e publicado, será possível gerenciar o representante de um cliente através do endpoint de `api/v1/profile_customers`, essa feature é suportada tanto na Criação quanto na Edição.

Exemplo de payload para adicionar um representante:
```json
{
    "profile_customer": {
        "represent_attributes": {
            "profile_admin_id": 3
        }
    }
}
```

Exemplo de payload para alterar um representante:
```json
{
    "profile_customer": {
        "represent_attributes": {
            "id": 2
            "profile_admin_id": 4
        }
    }
}
```